### PR TITLE
Feature canarie registry - platform stats

### DIFF
--- a/cwrc_core_tweaks.module
+++ b/cwrc_core_tweaks.module
@@ -169,20 +169,10 @@ function cwrc_core_tweaks_platform_statistics() {
 
     // Using data provided and gathered by the google analytics report.
     if ($is_ga_reports_enabled && ($report = views_get_view_result($name, $display_id)) && !empty($report[0])) {
-      $avg_session_duration = !empty($report[0]->avgSessionDuration) ? $report[0]->avgSessionDuration : 0;
-      $bounce_rate = !empty($report[0]->bounceRate) ? $report[0]->bounceRate : 0;
-      $page_views_per_session = !empty($report[0]->pageviewsPerSession) ? $report[0]->pageviewsPerSession : 0;
-      $percent_new_sessions = !empty($report[0]->percentNewSessions) ? $report[0]->percentNewSessions : 0;
       $last_time = variable_get('google_analytics_reports_metadata_last_time');
       $last_reset = format_date($last_time, 'custom', 'c') . 'Z';
       $info = array(
-//        'sessions' => !empty($report[0]->sessions) ? $report[0]->sessions : 0,
-//        'users' => !empty($report[0]->users) ? $report[0]->users : 0,
         'pageViews' => !empty($report[0]->pageviews) ? $report[0]->pageviews : 0,
-//        'pageviewsPerSession' => round($page_views_per_session, 2),
-//        'avgSessionDuration' => $avg_session_duration,
-//        'bounceRate' => round($bounce_rate, 2) . '%',
-//        'percentNewSessions' => round($percent_new_sessions, 2) . '%',
         'lastReset' => str_replace('+00:00', '', $last_reset),
       );
     }

--- a/cwrc_core_tweaks.module
+++ b/cwrc_core_tweaks.module
@@ -17,6 +17,13 @@ function cwrc_core_tweaks_menu() {
     'type' => MENU_CALLBACK,
   );
 
+  $items['platform/stats'] = array(
+    'title' => 'Platform Statistics',
+    'page callback' => 'cwrc_core_tweaks_platform_statistics',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
 }
 
@@ -145,4 +152,50 @@ function cwrc_core_tweaks_platform_information() {
   }
   $output .= '</dl>';
   return $output;
+}
+
+/**
+ * Display various platform statistics.
+ */
+function cwrc_core_tweaks_platform_statistics() {
+  $is_ga_reports_enabled = module_exists('google_analytics_reports');
+  $name = 'google_analytics_reports_summary';
+  $display_id = 'page';
+
+  // When an HTTP GET is performed on this URI, and the Accept header specifies
+  // JSON.
+  if (!empty($_SERVER['HTTP_ACCEPT']) && $_SERVER['HTTP_ACCEPT'] === 'application/json') {
+    $info = array();
+
+    // Using data provided and gathered by the google analytics report.
+    if ($is_ga_reports_enabled && ($report = views_get_view_result($name, $display_id)) && !empty($report[0])) {
+      $avg_session_duration = !empty($report[0]->avgSessionDuration) ? $report[0]->avgSessionDuration : 0;
+      $bounce_rate = !empty($report[0]->bounceRate) ? $report[0]->bounceRate : 0;
+      $page_views_per_session = !empty($report[0]->pageviewsPerSession) ? $report[0]->pageviewsPerSession : 0;
+      $percent_new_sessions = !empty($report[0]->percentNewSessions) ? $report[0]->percentNewSessions : 0;
+      $last_time = variable_get('google_analytics_reports_metadata_last_time');
+      $last_reset = format_date($last_time, 'custom', 'c') . 'Z';
+      $info = array(
+//        'sessions' => !empty($report[0]->sessions) ? $report[0]->sessions : 0,
+//        'users' => !empty($report[0]->users) ? $report[0]->users : 0,
+        'pageViews' => !empty($report[0]->pageviews) ? $report[0]->pageviews : 0,
+//        'pageviewsPerSession' => round($page_views_per_session, 2),
+//        'avgSessionDuration' => $avg_session_duration,
+//        'bounceRate' => round($bounce_rate, 2) . '%',
+//        'percentNewSessions' => round($percent_new_sessions, 2) . '%',
+        'lastReset' => str_replace('+00:00', '', $last_reset),
+      );
+    }
+    drupal_json_output($info);
+    drupal_exit();
+  }
+
+  // If an HTTP GET is performed and the Accept header does not indicate JSON,
+  // or there is no Accept header, platforms shall return an HTML page providing
+  // the information listed above in human-readable format. The content type for
+  // this response should specify “text/html”.
+  drupal_add_http_header('Content-Type', 'text/html; charset=utf-8');
+  $default = t('<p>No reporting functionalities was found</p>');
+  $output = $is_ga_reports_enabled ? views_embed_view($name, $display_id) : $default;
+  return $output ? $output : $default;
 }

--- a/cwrc_core_tweaks.module
+++ b/cwrc_core_tweaks.module
@@ -169,10 +169,20 @@ function cwrc_core_tweaks_platform_statistics() {
 
     // Using data provided and gathered by the google analytics report.
     if ($is_ga_reports_enabled && ($report = views_get_view_result($name, $display_id)) && !empty($report[0])) {
+      $avg_session_duration = !empty($report[0]->avgSessionDuration) ? $report[0]->avgSessionDuration : 0;
+      $bounce_rate = !empty($report[0]->bounceRate) ? $report[0]->bounceRate : 0;
+      $page_views_per_session = !empty($report[0]->pageviewsPerSession) ? $report[0]->pageviewsPerSession : 0;
+      $percent_new_sessions = !empty($report[0]->percentNewSessions) ? $report[0]->percentNewSessions : 0;
       $last_time = variable_get('google_analytics_reports_metadata_last_time');
       $last_reset = format_date($last_time, 'custom', 'c') . 'Z';
       $info = array(
+//        'sessions' => !empty($report[0]->sessions) ? $report[0]->sessions : 0,
+//        'users' => !empty($report[0]->users) ? $report[0]->users : 0,
         'pageViews' => !empty($report[0]->pageviews) ? $report[0]->pageviews : 0,
+//        'pageviewsPerSession' => round($page_views_per_session, 2),
+//        'avgSessionDuration' => $avg_session_duration,
+//        'bounceRate' => round($bounce_rate, 2) . '%',
+//        'percentNewSessions' => round($percent_new_sessions, 2) . '%',
         'lastReset' => str_replace('+00:00', '', $last_reset),
       );
     }

--- a/cwrc_core_tweaks.module
+++ b/cwrc_core_tweaks.module
@@ -111,7 +111,7 @@ function cwrc_core_tweaks_platform_information() {
     'synopsis' => t('CWRC enables researchers investigating writing and related cultural practices to leverage the power of digital tools. It promotes best practices with respect to metadata and data formats, collaboration, interoperability, and preservation. CWRC (pronounced QUIRK) is designed to foster collaboration among individuals and research groups focused on the study of cultural artifacts. The infrastructure combines computing hardware, software, and personnel to maintain a repository linked through a web-based service-oriented architecture and RESTful applications to a toolkit that enables digital humanities (DH) research.'),
     'version' => 1.0,
     'institution' => t('University of Alberta & University of Guelph'),
-    'releaseTime' => '2016-09-20',
+    'releaseTime' => '2016-09-20T13:00:00Z',
     'researchSubject' => t('Social sciences and humanities'),
     'supportEmail' => 'cwrc@ualberta.ca',
     'tags' => array(
@@ -121,6 +121,26 @@ function cwrc_core_tweaks_platform_information() {
       t('English'),
     ),
   );
+  if (!empty($_SERVER['HTTP_ACCEPT']) && $_SERVER['HTTP_ACCEPT'] === 'application/json') {
+    drupal_json_output($info);
+    drupal_exit();
+  }
 
-  drupal_json_output($info);
+  // Reusing some of the islandora classes so that we don't have to write our
+  // own css.
+  drupal_add_http_header('Content-Type', 'text/html; charset=utf-8');
+  $output = '<dl class="islandora-object-fields">';
+  foreach ($info as $item => $value) {
+    $class = 'dc-' . $item;
+    $class .= $item === 'name' ? ' first' : '';
+    $output .= "<dt class='{$class}'>{$item}</dt>";
+    if ($item === 'tags') {
+      $output .= '<dd>' . implode(',', $value) . '</dd>';
+    }
+    else {
+      $output .= "<dd>{$value}</dd>";
+    }
+  }
+  $output .= '</dl>';
+  return $output;
 }

--- a/cwrc_core_tweaks.module
+++ b/cwrc_core_tweaks.module
@@ -17,6 +17,13 @@ function cwrc_core_tweaks_menu() {
     'type' => MENU_CALLBACK,
   );
 
+  $items['platform/stats'] = array(
+    'title' => 'Platform Statistics',
+    'page callback' => 'cwrc_core_tweaks_platform_statistics',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
 }
 
@@ -145,4 +152,40 @@ function cwrc_core_tweaks_platform_information() {
   }
   $output .= '</dl>';
   return $output;
+}
+
+/**
+ * Display various platform statistics.
+ */
+function cwrc_core_tweaks_platform_statistics() {
+  $is_ga_reports_enabled = module_exists('google_analytics_reports');
+  $name = 'google_analytics_reports_summary';
+  $display_id = 'page';
+
+  // When an HTTP GET is performed on this URI, and the Accept header specifies
+  // JSON.
+  if (!empty($_SERVER['HTTP_ACCEPT']) && $_SERVER['HTTP_ACCEPT'] === 'application/json') {
+    $info = array();
+
+    // Using data provided and gathered by the google analytics report.
+    if ($is_ga_reports_enabled && ($report = views_get_view_result($name, $display_id)) && !empty($report[0])) {
+      $last_time = variable_get('google_analytics_reports_metadata_last_time');
+      $last_reset = format_date($last_time, 'custom', 'c') . 'Z';
+      $info = array(
+        'pageViews' => !empty($report[0]->pageviews) ? $report[0]->pageviews : 0,
+        'lastReset' => str_replace('+00:00', '', $last_reset),
+      );
+    }
+    drupal_json_output($info);
+    drupal_exit();
+  }
+
+  // If an HTTP GET is performed and the Accept header does not indicate JSON,
+  // or there is no Accept header, platforms shall return an HTML page providing
+  // the information listed above in human-readable format. The content type for
+  // this response should specify “text/html”.
+  drupal_add_http_header('Content-Type', 'text/html; charset=utf-8');
+  $default = t('<p>No reporting functionalities was found</p>');
+  $output = $is_ga_reports_enabled ? views_embed_view($name, $display_id) : $default;
+  return $output ? $output : $default;
 }

--- a/cwrc_core_tweaks.module
+++ b/cwrc_core_tweaks.module
@@ -129,16 +129,18 @@ function cwrc_core_tweaks_platform_information() {
   // Reusing some of the islandora classes so that we don't have to write our
   // own css.
   drupal_add_http_header('Content-Type', 'text/html; charset=utf-8');
-  $output = '<dl class="islandora-object-fields">';
+  $output = '<dl class="islandora-object-fields islandora-inline-metadata" style="width: 100%; float: none;">';
   foreach ($info as $item => $value) {
     $class = 'dc-' . $item;
     $class .= $item === 'name' ? ' first' : '';
+    $class = drupal_html_class($class);
+    $item = ucfirst($item);
     $output .= "<dt class='{$class}'>{$item}</dt>";
-    if ($item === 'tags') {
-      $output .= '<dd>' . implode(',', $value) . '</dd>';
+    if (strtolower($item) === 'tags') {
+      $output .= '<dd class="' . $class . '">' . implode(', ', $value) . '</dd>';
     }
     else {
-      $output .= "<dd>{$value}</dd>";
+      $output .= "<dd class='{$class}'>{$value}</dd>";
     }
   }
   $output .= '</dl>';


### PR DESCRIPTION
Added integration of platform stats page which will need https://www.drupal.org/project/google_analytics_reports and https://www.drupal.org/project/charts modules to be installed and configured prior to this pull request deployment. Note that if the two modules not installed and/or configured the stats page will still display but without any data.
